### PR TITLE
Excluded tests from release package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.80 Excluded tests from release package
+
 ## 0.0.79 Broken message handling fixed
 
 ## 0.0.78 Additional type for FSB14 added

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="eltako14bus",
-    version="0.0.79",
+    version="0.0.80",
     author="chrysn, grimmpp",
     author_email="chrysn@fsfe.org, grimmpp14@gmail.com",
     description="Library for participating in the Eltako Series 14 RS485 bus",
     url="https://github.com/grimmpp/eltako14bus",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(include=["eltakobus", "eltakobus.*"]),
     extras_require=extras_require,
     # Not that there'd be tests, but at least it fetches the right dependencies and syntax checks everything
     tests_require=list(set(sum(extras_require.values(), []))),


### PR DESCRIPTION
Hi @grimmpp
Thanks a lot for developing this library.
I want to add an Eltako integration to the official home assistant core using this library, but therefore the release package is not allowed to contain a test folder.
So my proposal has no functional change, but it will only remove the test folder from the release package.